### PR TITLE
Filter the shared segment file for hte network analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 *.csv
 .DS_Store
 network_images/
+network_imgs/

--- a/MEGA_ID.py
+++ b/MEGA_ID.py
@@ -109,7 +109,8 @@ def run(args):
 
         print("generating pdf files of networks of individuals who share segments...")
 
-        create_networks(args.segments_file, args.output)
+        create_networks(args.segments_file, args.var_file,
+                        args.var, args.output)
 
 
 def main():
@@ -137,6 +138,12 @@ def main():
 
     parser.add_argument("--shared_segments_file", help="This argument provides a path to the list of shared segments that can be used to form networks",
                         dest="segments_file", type=str, default=False)
+
+    parser.add_argument("--variant_file", help="This argument provides a path to a file that list all individuals that carry a specific variant",
+                        dest="var_file", type=str, default=False)
+
+    parser.add_argument("--var_of_interest", help="This argument passes a variant of interest that can filter down dataframes when trying to draw networks.",
+                        dest="var", type=str, default=False)
 
     parser.set_defaults(func=run)
     args = parser.parse_args()

--- a/create_networks.py
+++ b/create_networks.py
@@ -3,11 +3,14 @@ import logging
 from network_creator_class import Network_Img_Maker
 
 
-def create_networks(segments_file, output_path):
+def create_networks(segments_file, variant_file, variant_of_interest, output_path):
 
     logger = logging.getLogger(output_path+'/drawing_networks.log.log')
 
-    network_drawer = Network_Img_Maker(segments_file, output_path, logger)
+    network_drawer = Network_Img_Maker(
+        segments_file, variant_file, output_path, logger)
+
+    iid_list = network_drawer.isolate_variant_list(variant_of_interest)
 
     loaded_segments_file = network_drawer.check_file_exist(
         separator=",", header_value=None, skip_rows=5)
@@ -15,6 +18,7 @@ def create_networks(segments_file, output_path):
     loaded_segments_file = loaded_segments_file.drop(
         [0], axis=1).rename(columns={1: "Pairs"})
 
-    network_drawer_df = network_drawer.isolate_ids(loaded_segments_file)
+    network_drawer_df = network_drawer.isolate_ids(
+        loaded_segments_file, iid_list)
 
     network_drawer.draw_networks(network_drawer_df)

--- a/identify_single_var_carrier.py
+++ b/identify_single_var_carrier.py
@@ -22,9 +22,13 @@ from file_exist_checker import Check_File_Exist
 def totalVariantID(recodeFile, writeLocation):
     '''this is a function for the inner loop that will search through each position in the row and when it encouters a one or a two it will add that to the idlist and then return so that the outer loop in the main script moves on to the next row.'''
 
-    logging.info('Using raw recode file found at {}'.format(recodeFile))
+    logger = logging.getLogger(writeLocation+'/single_variant_analysis.log')
 
-    if path.exist(recodeFile):
+    logger.info('Determining just a list of all individuals who have carriers')
+
+    logger.info('Using raw recode file found at {}'.format(recodeFile))
+
+    if path.exists(recodeFile[0]):
 
         with open(recodeFile[0]) as geno_file:
 
@@ -46,7 +50,7 @@ def totalVariantID(recodeFile, writeLocation):
             print("The total number of individual carrier of at least one desired variant is: {}".format(
                 len(totalVariantList)))
 
-            logging.info("The total number of individual carrier of at least one desired variant is: {}".format(
+            logger.info("The total number of individual carrier of at least one desired variant is: {}".format(
                 len(totalVariantList)))
 
             writeDirectory = writePath(writeLocation, "totalVariantIDList.txt")
@@ -62,7 +66,7 @@ def totalVariantID(recodeFile, writeLocation):
     else:
 
         print("The raw recoded file at {} was not found.".format())
-        logging.error("The raw recoded file at {} was not found.".format())
+        logger.error("The raw recoded file at {} was not found.".format())
 
 ############################################################################################
 # This function determines all the individuals who have a specific variant
@@ -70,6 +74,8 @@ def totalVariantID(recodeFile, writeLocation):
 
 def singleVariantAnalysis(recodeFile, write_path, reformat, fileName):
     '''This function returns a csv containing a list of individuals who carry each variants. It takes a recoded variant file, a path to write the output to, and a file name'''
+
+    totalVariantID(recodeFile, write_path)
 
     logger = logging.getLogger(write_path+'/single_variant_analysis.log')
 


### PR DESCRIPTION
Adjusted the network analysis so that the shared_segment file could be subset for only individuals who carry a desired variant and then removed all pairs only identified by GERMLINE.This functionality is found in the isolate_variant_list method which gets a list of iid's for carriers and the isolat_ids which filters the shared segment dataframe. Also updated the MEGA_ID.py with some new arguments that facilitate this process. Also updated gitignore.